### PR TITLE
Fixed the Lifecycle scripts included in hello-world:

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Stock tracker in Angular 2",
   "main": "server/bootstrap.js",
   "scripts": {
-    "start": "npm install && node ./node_modules/gulp/bin/gulp.js start"
+    "start": "npm install && node ./node_modules/gulp/bin/gulp.js go"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The `npm start` script was failing because there is not `start` task in the gulpfile. I updated it to `gulp go`.
